### PR TITLE
Use secure URI in Homepage field.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fortunes-mario (0.21-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Homepage field.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 01:12:28 +0100
+
 fortunes-mario (0.21-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Uploaders: Fernando Ike de Oliveira <fike@midstorm.org>
 Build-Depends: debhelper (>= 9)
 Build-Depends-Indep: fortune-mod (>= 1.99.1-6)
 Standards-Version: 3.9.6
-Homepage: http://github.com/fike/fortunes-mario
+Homepage: https://github.com/fike/fortunes-mario
 Vcs-Browser: http://github.com/fike/fortunes-mario-deb
 Vcs-Git: git://github.com/fike/fortunes-mario-deb
 


### PR DESCRIPTION
Use secure URI in Homepage field.

Fixes lintian: homepage-field-uses-insecure-uri
See https://lintian.debian.org/tags/homepage-field-uses-insecure-uri.html for more details.
