### PR TITLE
Ship the actual book PDF instead of its build files

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,8 +3,14 @@ Section: games
 Priority: optional
 Maintainer: Otavio Salvador <otavio@debian.org>
 Uploaders: Fernando Ike de Oliveira <fike@midstorm.org>
-Build-Depends: debhelper (>= 9)
-Build-Depends-Indep: fortune-mod (>= 1.99.1-6)
+Build-Depends: debhelper (>= 9),
+               fortune-mod (>= 1.99.1-6),
+               ghostscript,
+               poppler-utils,
+               psutils,
+               python3,
+               texlive-lang-portuguese,
+               texlive-latex-extra
 Standards-Version: 3.9.6
 Homepage: https://github.com/fike/fortunes-mario
 Vcs-Browser: http://github.com/fike/fortunes-mario-deb
@@ -13,7 +19,6 @@ Vcs-Git: git://github.com/fike/fortunes-mario-deb
 Package: fortunes-mario
 Architecture: all
 Depends: fortune-mod (>= 1.99.1-6), 
-         python, 
          ${misc:Depends}
 Provides: fortune-cookie-db
 Description: Fortunes files from Mario

--- a/debian/docs
+++ b/debian/docs
@@ -3,3 +3,4 @@ LEIAME
 BUGS
 CREDITOS
 LICENCA
+livro/mario_fortunes-livro.pdf

--- a/debian/install
+++ b/debian/install
@@ -1,2 +1,1 @@
 mario.*	usr/share/games/fortunes/
-livro	usr/share/games/fortunes/

--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,8 @@
 
 override_dh_auto_clean:
 	rm -f *.dat
+	cd livro && $(MAKE) clean
 
 override_dh_auto_build:
 	find -name "mario.*" -exec strfile {} \;
+	cd livro && $(MAKE)


### PR DESCRIPTION
This will work in combination with the changes in
https://github.com/fike/fortunes-mario/pull/2.

In a source package with just "Architecture: all" binary packages, Build-Depends and
Build-Depends-Indep can be merged.

"Depends: python" removed because the livro.py script will not be shipped any longer.

See also https://bugs.debian.org/945672.